### PR TITLE
Escape ampersands in CC-CEDICT definitions to avoid build failure.

### DIFF
--- a/build_dict.pl
+++ b/build_dict.pl
@@ -42,7 +42,7 @@ while (<$fh>) {
 		raw_simp => $simp,
 		py => [split ' ', $py],
 		raw_py => lc($py),
-		defs => [split '/', $defs =~ s/&/&amp;/rg],
+		defs => [split '/', $defs],
 		id => "${simp}_${id}",
 	};
 	
@@ -139,6 +139,9 @@ foreach my $entry (sort common_first map { @$_ } values %entries) {
 	# print out a list element for each definition
 	my $mw = '';
 	foreach my $def (@{$entry->{defs}}) {
+		# Escape ampersands first, before more are created by subsequent escaping
+		$def =~ s/&/&amp;/g;
+
 		$def =~ s/</&lt;/g;
 		$def =~ s/>/&gt;/g;
 		

--- a/build_dict.pl
+++ b/build_dict.pl
@@ -42,7 +42,7 @@ while (<$fh>) {
 		raw_simp => $simp,
 		py => [split ' ', $py],
 		raw_py => lc($py),
-		defs => [split '/', $defs],
+		defs => [split '/', $defs =~ s/&/&amp;/rg],
 		id => "${simp}_${id}",
 	};
 	


### PR DESCRIPTION
Updated build_dict.pl to escape ampersands in CC-CEDICT definition fields (to &amp;amp;) to avoid parsing errors during _make_ in MyDictionary.xml such as:

```
MyDictionary.xml:63808: parser error : xmlParseEntityRef: no name
			<li>China National Aero-Technology Import & Export Corporation (CATIC)</li>
			                                           ^
MyDictionary.xml : failed to parse
```

This error occurs with the 2017-02-19 dictionary from https://www.mdbg.net/chindict/chindict.php?page=cedict.

(Aside - thanks for making your project available on Github!)